### PR TITLE
resetScrollOnUpdateChildrens property 

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "author": "lxavier",
   "name": "react-spinetic",
   "homepage": "https://iq-tech.github.io/spinetic/?path=/docs/pages-playground--documentation",
-  "version": "0.1.27",
+  "version": "0.1.28",
   "description": "A lightweight React carousel library for creating interactive carousels in your web applications.",
   "private": false,
   "keywords": [

--- a/src/spinetic/helpers/defaults.ts
+++ b/src/spinetic/helpers/defaults.ts
@@ -42,6 +42,8 @@ export const _defaultConfig: T.TypesConfig = {
     clickTransitionCtrl: false,
     msPerClicks: 1500,
 
+    resetScrollOnUpdateChildrens: true,
+
     responsive: [{ breakpoint: 0, settings: {} }],
 };
 

--- a/src/spinetic/helpers/validator.ts
+++ b/src/spinetic/helpers/validator.ts
@@ -62,6 +62,8 @@ export const validConfig = (config?: T.TypesConfigOptional): T.TypesConfig => {
     clickTransitionCtrl: C?.clickTransitionCtrl ?? DC.clickTransitionCtrl,
     msPerClicks: C?.msPerClicks ?? DC.msPerClicks,
 
+    resetScrollOnUpdateChildrens: C?.resetScrollOnUpdateChildrens ?? DC?.resetScrollOnUpdateChildrens,
+
     responsive: _validResponsive(C?.responsive)
   };
 

--- a/src/spinetic/hooks/index.ts
+++ b/src/spinetic/hooks/index.ts
@@ -151,7 +151,7 @@ export const useSpinetic = ({
       elementsChange?.current?.remainingIndexes,
       currentRemainingIdx)
 
-    if (!remainingidxIsEquals) setCurrentIndex(0);
+    if (!remainingidxIsEquals && currentConfig.resetScrollOnUpdateChildrens) setCurrentIndex(0);
 
     const hasDraggable = CConfig.draggable && remainingIndexes?.length > 1;
     spineticContainer.current?.classList.toggle("hasDraggable", hasDraggable);

--- a/src/stories/argTypes.ts
+++ b/src/stories/argTypes.ts
@@ -299,6 +299,22 @@ ________________________________________________________________________________
         },
     },
 
+    resetScrollOnUpdateChildrens:  {
+        description: `<span id="resetScrollOnUpdateChildrens">Determines if the carousel should reset to the start position when child elements are updated.</span>`,
+        control: "boolean",
+        table: {
+            type: { 
+                summary: "boolean",
+                detail: `
+When enabled (true), the carousel returns to the start position whenever its child elements are modified. 
+If disabled (false), the carousel will maintain its current position even if the child elements are changed.
+                            
+_________________________________________________________________________________________________
+                                ` },
+            defaultValue: { summary: D._defaultConfig.resetScrollOnUpdateChildrens },
+        },
+    },
+
 
 
     draggable: {

--- a/src/stories/docs/Props.mdx
+++ b/src/stories/docs/Props.mdx
@@ -49,7 +49,10 @@ export interface TypesConfigOptional {
   groupScroll?: boolean;
   groupItemsScroll?: number;
 
+  resetScrollOnUpdateChildrens?: boolean;
+
   responsive?: TypesReponsiveSettings[];
+  
 }
 
 interface TypesReponsiveSettings {
@@ -69,6 +72,7 @@ interface TypesReponsiveSettings {
 
 - [autoRotate](?path=/docs/pages-playground--documentation#autoRotate): <span dangerouslySetInnerHTML={{ __html:argTypes.autoRotate.description}} />
 - [msPerAutoRotate](?path=/docs/pages-playground--documentation#msPerAutoRotate): <span dangerouslySetInnerHTML={{ __html:argTypes.msPerAutoRotate.description}} />
+- [resetScrollOnUpdateChildrens](?path=/docs/pages-playground--documentation#resetScrollOnUpdateChildrens): <span dangerouslySetInnerHTML={{ __html:argTypes.resetScrollOnUpdateChildrens.description}} />
 
 - [draggable](?path=/docs/pages-playground--documentation#draggable): <span dangerouslySetInnerHTML={{ __html:argTypes.draggable.description}} />
 - [touchThreshold](?path=/docs/pages-playground--documentation#touchThreshold): <span dangerouslySetInnerHTML={{ __html:argTypes.touchThreshold.description}} />

--- a/types.d.ts
+++ b/types.d.ts
@@ -45,6 +45,8 @@ export interface TypesConfigOptional {
   groupScroll?: boolean;
   groupItemsScroll?: number;
 
+  resetScrollOnUpdateChildrens?: boolean;
+  
   responsive?: TypesReponsiveSettings[];
 }
 


### PR DESCRIPTION
Este PR adiciona a propriedade `resetScrollOnUpdateChildren`, que será responsável por controlar o retorno do carrossel ao início sempre que os itens filhos forem atualizados.