### PR TITLE
CustomChildrenDots

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "author": "lxavier",
   "name": "react-spinetic",
   "homepage": "https://iq-tech.github.io/spinetic/?path=/docs/pages-playground--documentation",
-  "version": "0.1.28",
+  "version": "0.1.31",
   "description": "A lightweight React carousel library for creating interactive carousels in your web applications.",
   "private": false,
   "keywords": [

--- a/src/spinetic/components/Dots/index.tsx
+++ b/src/spinetic/components/Dots/index.tsx
@@ -9,6 +9,8 @@ const Dots = ({
   maxCarouselItems,
   remainingIndexes,
   goToItem,
+
+  CustomChildrenDots,
 }: T.TypesDots) => {
   const { visibleDots, hasMaxDots, dotsMainRef, dotsContainerRef } = useDots({
     currentConfig,
@@ -18,7 +20,7 @@ const Dots = ({
 
   return (
     <>
-      {visibleDots && hasMaxDots && (
+      {visibleDots && hasMaxDots && !CustomChildrenDots && (
         <div className="spinetic-dots-main" ref={dotsMainRef}>
           <div className="spinetic-dots-wrapper">
             <div
@@ -52,7 +54,7 @@ const Dots = ({
         </div>
       )}
 
-      {visibleDots && !hasMaxDots && (
+      {visibleDots && !hasMaxDots && !CustomChildrenDots && (
         <div
           className="spinetic-dots"
           style={{ ...currentConfig.dotsStyle?.container }}
@@ -79,6 +81,13 @@ const Dots = ({
             </span>
           ))}
         </div>
+      )}
+
+      {visibleDots && CustomChildrenDots && (
+        <CustomChildrenDots
+          currentIndex={currentIndex}
+          remainingIndexes={remainingIndexes}
+        />
       )}
     </>
   );

--- a/src/spinetic/index.tsx
+++ b/src/spinetic/index.tsx
@@ -6,7 +6,7 @@ import { useSpinetic } from "./hooks";
 import * as T from "types";
 import Scrollbar from "./components/Scrollbar";
 
-const Spinetic = ({ children, config, change }: T.TypesSpinetic) => {
+const Spinetic = ({ children, CustomChildrenDots, config, change }: T.TypesSpinetic) => {
   const {
     currentConfig,
     progressIndicatorType,
@@ -64,6 +64,7 @@ const Spinetic = ({ children, config, change }: T.TypesSpinetic) => {
                 maxCarouselItems={maxCarouselItems}
                 remainingIndexes={remainingIndexes}
                 goToItem={goToItem}
+                CustomChildrenDots={CustomChildrenDots}
               />
             )}
 

--- a/src/stories/argTypes.ts
+++ b/src/stories/argTypes.ts
@@ -56,6 +56,36 @@ ________________________________________________________________________________
     },
 
 
+    CustomChildrenDots: {
+        description: `<span id="CustomChildrenDots">Component to customize the dots, receiving the current item's index (currentIndex) and the remaining items' indexes (remainingIndexes) as props.</span>`,
+        control: "ReactNode",
+        table: {
+            type: {
+                summary: "<currentIndex | remainingIndexes>ReactNode",
+                detail: `
+The "CustomChildrenDots" prop allows you to customize the rendering of the dots based on the current index and the remaining indexes.
+
+For example:
+
+<Spinetic CustomChildrenDots={({currentIndex, remainingIndexes}) => {
+    return <h1>Current item: {currentIndex+1} Remaining items: {remainingIndexes?.length}</h1>;
+}}>
+    {["content-1", "content-2", "content-3"].map((content, index) => (
+        <SpineticItem key={index}>
+            <div style={{ height: 200, width: 250, background: "blue", margin: 10 }}>
+                {content}
+            </div>
+        </SpineticItem>
+    ))}
+</Spinetic>
+`
+            },
+            defaultValue: { summary: undefined },
+        },
+    },
+
+
+
     config: {
         description: `The config prop accepts an object with optional settings to customize the Spinetic component. 
         Here are the available types:`,

--- a/src/stories/docs/Props.mdx
+++ b/src/stories/docs/Props.mdx
@@ -17,6 +17,26 @@ import { GoToTheTop } from "../CardExample.tsx";
 
 Children elements to be rendered inside the Spinetic component. It can be a single `ReactNode` or an _array_ of `ReactNodes`.
 
+
+## `CustomChildrenDots`: _ReactNode_ or _ReactNode[]_
+prop allows you to customize the rendering of the dots based on the current index and the remaining indexes.
+
+### Example Usage:
+
+```tsx
+<Spinetic CustomChildrenDots={({currentIndex, remainingIndexes}) => {
+    return <h1>C Current item: {currentIndex+1} Remaining items: {remainingIndexes?.length}</h1>;
+}}>
+    {["content-1", "content-2", "content-3"].map((content, index) => (
+        <SpineticItem key={index}>
+            <div style={{ height: 200, width: 250, background: "blue", margin: 10 }}>
+                {content}
+            </div>
+        </SpineticItem>
+    ))}
+</Spinetic>
+```
+
 ## `config`: _TypesConfigOptional_
 
 The `config` prop accepts an object with optional settings for customizing the Spinetic component. To run tests and explore detailed information about each property and its functionality, navigate by clicking on individual properties and experiment with them in the playground:

--- a/types.d.ts
+++ b/types.d.ts
@@ -114,7 +114,7 @@ export interface TypesSpinetic {
   children: TypeChildren;
   config?: TypesConfigOptional;
 
-  CustomChildrenDots?: any; // TODO: type
+  CustomChildrenDots?: (args: { currentIndex: number; remainingIndexes: number[] }) => ReactNode;
 
   change?: (e: SpineticChangeEvent) => void;
 }
@@ -159,7 +159,7 @@ export interface TypesDots {
   remainingIndexes: number[];
   goToItem: (p0: number) => void;
 
-  CustomChildrenDots: any // TODO: type
+  CustomChildrenDots?: (args: { currentIndex: number; remainingIndexes: number[] }) => ReactNode;
 }
 
 export interface TypesScrollbar {

--- a/types.d.ts
+++ b/types.d.ts
@@ -113,6 +113,9 @@ type TypeChildren = ReactNode | ReactNode[] | object | null | undefined | any;
 export interface TypesSpinetic {
   children: TypeChildren;
   config?: TypesConfigOptional;
+
+  CustomChildrenDots?: any; // TODO: type
+
   change?: (e: SpineticChangeEvent) => void;
 }
 
@@ -155,6 +158,8 @@ export interface TypesDots {
   maxCarouselItems: number;
   remainingIndexes: number[];
   goToItem: (p0: number) => void;
+
+  CustomChildrenDots: any // TODO: type
 }
 
 export interface TypesScrollbar {


### PR DESCRIPTION
Adicionando a pro `CustomChildrenDots`, que receberá um componente React. Esse componente terá como prop o item atual e os itens restantes, permitindo personalizar os pontinhos.

Exemplo:

https://github.com/user-attachments/assets/ec12f493-5946-4f19-a499-7cc00c71fa21

